### PR TITLE
refactor(eslint-config-vitest, eslint-config-internal):  remove unnecessary type assertion

### DIFF
--- a/.changeset/afraid-waves-care.md
+++ b/.changeset/afraid-waves-care.md
@@ -1,0 +1,6 @@
+---
+"@zphyrx/eslint-config-vitest": patch
+"@zphyrx/eslint-config-internal": patch
+---
+
+Remove TypeScript’s non-null assertion (`!`) for `vitestPlugin.configs.recommended` in the `extends` field

--- a/internal/eslint-config/eslint.config.mts
+++ b/internal/eslint-config/eslint.config.mts
@@ -8,7 +8,6 @@ const config: TSESLint.FlatConfig.ConfigArray = [
     name: "@zphyrx/eslint-config-internal/typescript",
     rules: {
       "import-x/no-named-as-default-member": "off",
-      "@typescript-eslint/no-non-null-assertion": "off",
     },
   },
 ];

--- a/internal/eslint-config/src/config.ts
+++ b/internal/eslint-config/src/config.ts
@@ -46,7 +46,7 @@ const config: TSESLint.FlatConfig.ConfigArray = tseslint.config(
     },
   },
   {
-    extends: [vitestPlugin.configs!.recommended],
+    extends: [vitestPlugin.configs.recommended],
     name: "@zphyrx/eslint-config-internal/vitest",
     files: GLOB_TESTS,
     rules: {

--- a/packages/configs/eslint-config-vitest/eslint.config.mts
+++ b/packages/configs/eslint-config-vitest/eslint.config.mts
@@ -2,15 +2,6 @@ import * as base from "@zphyrx/eslint-config-internal";
 
 import type { TSESLint } from "@typescript-eslint/utils";
 
-const config: TSESLint.FlatConfig.ConfigArray = [
-  ...base.config,
-  {
-    name: "@zphyrx/eslint-config-internal/typescript",
-    rules: {
-      "@typescript-eslint/no-unsafe-assignment": "off",
-      "@typescript-eslint/no-non-null-assertion": "off",
-    },
-  },
-];
+const config: TSESLint.FlatConfig.ConfigArray = [...base.config, {}];
 
 export default config;

--- a/packages/configs/eslint-config-vitest/src/config.ts
+++ b/packages/configs/eslint-config-vitest/src/config.ts
@@ -5,7 +5,7 @@ import { rulesVitest } from "./rules";
 import type { TSESLint } from "@typescript-eslint/utils";
 
 const _extends: TSESLint.FlatConfig.ConfigArray = [
-  vitestPlugin.configs!.recommended,
+  vitestPlugin.configs.recommended,
 ];
 
 const _files: (string | string[])[] = ["**/?(*.)+(spec|test).ts?(x)"];


### PR DESCRIPTION
<!--

Thank you for your contribution! To help us process your pull request (PR) quickly, please follow the steps below:

- 📝 Use a clear and meaningful title for the PR, including the name of the modified package.
- 👀 Review your PR thoroughly to ensure you haven't missed anything.

-->

### Description

This PR removes the unnecessary non-null assertion (`!`) from `vitestPlugin.configs.recommended` in the `extends` field of both the `eslint-config-vitest` and `eslint-config-internal` packages.

Specifically, it changes from:

```ts
const _extends: TSESLint.FlatConfig.ConfigArray = [
  vitestPlugin.configs!.recommended,
];
```

to:

```ts
const _extends: TSESLint.FlatConfig.ConfigArray = [
  vitestPlugin.configs.recommended,
];
```
