### PR TITLE
refactor @typescript-eslint/utils imports

### DIFF
--- a/.changeset/giant-walls-drum.md
+++ b/.changeset/giant-walls-drum.md
@@ -1,0 +1,21 @@
+---
+"@zphyrx/eslint-config-testing-library": patch
+"@zphyrx/eslint-config-tailwindcss": patch
+"@zphyrx/eslint-config-typescript": patch
+"@zphyrx/eslint-config-storybook": patch
+"@zphyrx/eslint-config-import-x": patch
+"@zphyrx/eslint-config-jsx-a11y": patch
+"@zphyrx/eslint-config-prettier": patch
+"@zphyrx/eslint-config-vitest": patch
+"@zphyrx/eslint-config-react": patch
+"@zphyrx/eslint-config-jest": patch
+"@zphyrx/prettier-config": patch
+"@zphyrx/postcss-config": patch
+"@zphyrx/vitest-config": patch
+"@zphyrx/merge-config": patch
+"@zphyrx/tsup-config": patch
+"@zphyrx/exlint": patch
+"@zphyrx/eslint-config-internal": patch
+---
+
+Refactor `@typescript-eslint/utils` imports

--- a/internal/eslint-config/eslint.config.mts
+++ b/internal/eslint-config/eslint.config.mts
@@ -1,8 +1,8 @@
 import * as base from "./src/index";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config: TSESLint.FlatConfig.ConfigArray = [
+const config: FlatConfig.ConfigArray = [
   ...base.config,
   {
     name: "@zphyrx/eslint-config-internal/typescript",

--- a/internal/eslint-config/src/config.ts
+++ b/internal/eslint-config/src/config.ts
@@ -6,9 +6,9 @@ import prettierPlugin from "eslint-plugin-prettier/recommended";
 import { GLOB_TESTS, GLOB_TS } from "./globs";
 import * as rules from "./rules";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config: TSESLint.FlatConfig.ConfigArray = tseslint.config(
+const config: FlatConfig.ConfigArray = tseslint.config(
   {
     name: "@zphyrx/eslint-config-internal/global-ignores",
     ignores: ["**/node_modules/**", "**/dist/**", "**/coverage/**"],

--- a/internal/eslint-config/src/rules/import-x.ts
+++ b/internal/eslint-config/src/rules/import-x.ts
@@ -1,6 +1,6 @@
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const rules: TSESLint.FlatConfig.Rules = {
+const rules: FlatConfig.Rules = {
   "import-x/namespace": "error",
   "import-x/first": "error",
   "import-x/no-amd": "error",

--- a/internal/eslint-config/src/rules/prettier.ts
+++ b/internal/eslint-config/src/rules/prettier.ts
@@ -1,6 +1,6 @@
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const rules: TSESLint.FlatConfig.Rules = {
+const rules: FlatConfig.Rules = {
   "prettier/prettier": [
     "error",
     {

--- a/internal/eslint-config/src/rules/typescript.ts
+++ b/internal/eslint-config/src/rules/typescript.ts
@@ -1,6 +1,6 @@
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const rules: TSESLint.FlatConfig.Rules = {
+const rules: FlatConfig.Rules = {
   "no-dupe-class-members": "off",
   "no-duplicate-imports": "error",
   "no-undef": "off",

--- a/internal/eslint-config/src/rules/vitest.ts
+++ b/internal/eslint-config/src/rules/vitest.ts
@@ -1,6 +1,6 @@
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const rules: TSESLint.FlatConfig.Rules = {
+const rules: FlatConfig.Rules = {
   "vitest/consistent-test-it": [
     "warn",
     {

--- a/packages/configs/eslint-config-import-x/eslint.config.mts
+++ b/packages/configs/eslint-config-import-x/eslint.config.mts
@@ -1,7 +1,7 @@
 import * as base from "@zphyrx/eslint-config-internal";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config: TSESLint.FlatConfig.ConfigArray = [...base.config, {}];
+const config: FlatConfig.ConfigArray = [...base.config, {}];
 
 export default config;

--- a/packages/configs/eslint-config-import-x/src/config.ts
+++ b/packages/configs/eslint-config-import-x/src/config.ts
@@ -2,16 +2,16 @@ import importXPlugin from "eslint-plugin-import-x";
 
 import { rulesImportX } from "./rules";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const _extends: TSESLint.FlatConfig.ConfigArray = [
+const _extends: FlatConfig.ConfigArray = [
   importXPlugin.flatConfigs.recommended,
   importXPlugin.flatConfigs.typescript,
 ];
 
 const _files: (string | string[])[] = ["**/*.ts?(x)", "**/*.mts"];
 
-const _rules: TSESLint.FlatConfig.Rules = {
+const _rules: FlatConfig.Rules = {
   ...rulesImportX,
 };
 

--- a/packages/configs/eslint-config-import-x/src/rules/import-x.ts
+++ b/packages/configs/eslint-config-import-x/src/rules/import-x.ts
@@ -1,6 +1,6 @@
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const rules: TSESLint.FlatConfig.Rules = {
+const rules: FlatConfig.Rules = {
   "import-x/namespace": "error",
   "import-x/first": "error",
   "import-x/no-amd": "error",

--- a/packages/configs/eslint-config-jest/eslint.config.mts
+++ b/packages/configs/eslint-config-jest/eslint.config.mts
@@ -1,7 +1,7 @@
 import * as base from "@zphyrx/eslint-config-internal";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config: TSESLint.FlatConfig.ConfigArray = [...base.config, {}];
+const config: FlatConfig.ConfigArray = [...base.config, {}];
 
 export default config;

--- a/packages/configs/eslint-config-jest/src/config.ts
+++ b/packages/configs/eslint-config-jest/src/config.ts
@@ -2,16 +2,16 @@ import jestPlugin from "eslint-plugin-jest";
 
 import { rulesJest } from "./rules";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const _extends: TSESLint.FlatConfig.ConfigArray = [
+const _extends: FlatConfig.ConfigArray = [
   jestPlugin.configs["flat/recommended"],
   jestPlugin.configs["flat/style"],
 ];
 
 const _files: (string | string[])[] = ["**/?(*.)+(spec|test).ts?(x)"];
 
-const _rules: TSESLint.FlatConfig.Rules = {
+const _rules: FlatConfig.Rules = {
   ...rulesJest,
 };
 

--- a/packages/configs/eslint-config-jest/src/rules/jest.ts
+++ b/packages/configs/eslint-config-jest/src/rules/jest.ts
@@ -1,6 +1,6 @@
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const rules: TSESLint.FlatConfig.Rules = {
+const rules: FlatConfig.Rules = {
   "jest/consistent-test-it": [
     "warn",
     {

--- a/packages/configs/eslint-config-jsx-a11y/eslint.config.mts
+++ b/packages/configs/eslint-config-jsx-a11y/eslint.config.mts
@@ -1,7 +1,7 @@
 import * as base from "@zphyrx/eslint-config-internal";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config: TSESLint.FlatConfig.ConfigArray = [...base.config, {}];
+const config: FlatConfig.ConfigArray = [...base.config, {}];
 
 export default config;

--- a/packages/configs/eslint-config-jsx-a11y/src/config.ts
+++ b/packages/configs/eslint-config-jsx-a11y/src/config.ts
@@ -2,15 +2,15 @@ import jsxA11yPlugin from "eslint-plugin-jsx-a11y";
 
 import { rulesJsxA11y } from "./rules";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const _extends: TSESLint.FlatConfig.ConfigArray = [
+const _extends: FlatConfig.ConfigArray = [
   jsxA11yPlugin.flatConfigs.recommended,
 ];
 
 const _files: (string | string[])[] = ["**/*.ts?(x)", "**/*.mts"];
 
-const _rules: TSESLint.FlatConfig.Rules = {
+const _rules: FlatConfig.Rules = {
   ...rulesJsxA11y,
 };
 

--- a/packages/configs/eslint-config-jsx-a11y/src/rules/jsx-a11y.ts
+++ b/packages/configs/eslint-config-jsx-a11y/src/rules/jsx-a11y.ts
@@ -1,6 +1,6 @@
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const rules: TSESLint.FlatConfig.Rules = {
+const rules: FlatConfig.Rules = {
   "jsx-a11y/alt-text": "warn",
   "jsx-a11y/anchor-has-content": [
     "warn",

--- a/packages/configs/eslint-config-prettier/eslint.config.mts
+++ b/packages/configs/eslint-config-prettier/eslint.config.mts
@@ -1,7 +1,7 @@
 import * as base from "@zphyrx/eslint-config-internal";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config: TSESLint.FlatConfig.ConfigArray = [...base.config, {}];
+const config: FlatConfig.ConfigArray = [...base.config, {}];
 
 export default config;

--- a/packages/configs/eslint-config-prettier/src/config.ts
+++ b/packages/configs/eslint-config-prettier/src/config.ts
@@ -2,13 +2,13 @@ import prettierPlugin from "eslint-plugin-prettier/recommended";
 
 import { rulesPrettier } from "./rules";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const _extends: TSESLint.FlatConfig.ConfigArray = [prettierPlugin];
+const _extends: FlatConfig.ConfigArray = [prettierPlugin];
 
 const _files: (string | string[])[] = ["**/*.ts?(x)", "**/*.mts"];
 
-const _rules: TSESLint.FlatConfig.Rules = {
+const _rules: FlatConfig.Rules = {
   ...rulesPrettier,
 };
 

--- a/packages/configs/eslint-config-prettier/src/rules/prettier.ts
+++ b/packages/configs/eslint-config-prettier/src/rules/prettier.ts
@@ -1,6 +1,6 @@
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const rules: TSESLint.FlatConfig.Rules = {
+const rules: FlatConfig.Rules = {
   "prettier/prettier": [
     "error",
     {

--- a/packages/configs/eslint-config-react/eslint.config.mts
+++ b/packages/configs/eslint-config-react/eslint.config.mts
@@ -1,8 +1,8 @@
 import * as base from "@zphyrx/eslint-config-internal";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config: TSESLint.FlatConfig.ConfigArray = [
+const config: FlatConfig.ConfigArray = [
   ...base.config,
   {
     name: "@zphyrx/eslint-config-internal/typescript",

--- a/packages/configs/eslint-config-react/src/config.ts
+++ b/packages/configs/eslint-config-react/src/config.ts
@@ -4,7 +4,7 @@ import { FlatCompat } from "@eslint/eslintrc";
 
 import { rulesReact, rulesReactHooks } from "./rules";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
 const cwd = process.cwd();
 
@@ -12,21 +12,21 @@ const compat = new FlatCompat({
   baseDirectory: cwd,
 });
 
-const _extends: TSESLint.FlatConfig.ConfigArray = [
-  reactPlugin.configs.flat!.recommended as TSESLint.FlatConfig.Config,
-  reactPlugin.configs.flat!.recommended as TSESLint.FlatConfig.Config,
-  reactPlugin.configs.flat!["jsx-runtime"] as TSESLint.FlatConfig.Config,
+const _extends: FlatConfig.ConfigArray = [
+  reactPlugin.configs.flat!.recommended as FlatConfig.Config,
+  reactPlugin.configs.flat!.recommended as FlatConfig.Config,
+  reactPlugin.configs.flat!["jsx-runtime"] as FlatConfig.Config,
   ...fixupConfigRules(compat.extends("plugin:react-hooks/recommended")),
 ];
 
 const _files: (string | string[])[] = ["**/*.ts?(x)", "**/*.mts"];
 
-const _rules: TSESLint.FlatConfig.Rules = {
+const _rules: FlatConfig.Rules = {
   ...rulesReact,
   ...rulesReactHooks,
 };
 
-const _settings: TSESLint.FlatConfig.Settings = {
+const _settings: FlatConfig.Settings = {
   react: {
     version: "detect",
   },

--- a/packages/configs/eslint-config-react/src/rules/react-hooks.ts
+++ b/packages/configs/eslint-config-react/src/rules/react-hooks.ts
@@ -1,6 +1,6 @@
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const rules: TSESLint.FlatConfig.Rules = {
+const rules: FlatConfig.Rules = {
   /**
    *  react-hooks
    *

--- a/packages/configs/eslint-config-react/src/rules/react.ts
+++ b/packages/configs/eslint-config-react/src/rules/react.ts
@@ -1,6 +1,6 @@
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const rules: TSESLint.FlatConfig.Rules = {
+const rules: FlatConfig.Rules = {
   "react/display-name": "warn",
   "react/forbid-foreign-prop-types": [
     "warn",

--- a/packages/configs/eslint-config-storybook/eslint.config.mts
+++ b/packages/configs/eslint-config-storybook/eslint.config.mts
@@ -1,7 +1,7 @@
 import * as base from "@zphyrx/eslint-config-internal";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config: TSESLint.FlatConfig.ConfigArray = [...base.config, {}];
+const config: FlatConfig.ConfigArray = [...base.config, {}];
 
 export default config;

--- a/packages/configs/eslint-config-storybook/src/config.ts
+++ b/packages/configs/eslint-config-storybook/src/config.ts
@@ -2,15 +2,15 @@ import storybookPlugin from "eslint-plugin-storybook";
 
 import { rulesStorybook } from "./rules";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const _extends: TSESLint.FlatConfig.ConfigArray = [
+const _extends: FlatConfig.ConfigArray = [
   ...storybookPlugin.configs["flat/recommended"],
 ];
 
 const _files: (string | string[])[] = ["**/*.stories.ts?(x)"];
 
-const _rules: TSESLint.FlatConfig.Rules = {
+const _rules: FlatConfig.Rules = {
   ...rulesStorybook,
 };
 

--- a/packages/configs/eslint-config-storybook/src/rules/storybook.ts
+++ b/packages/configs/eslint-config-storybook/src/rules/storybook.ts
@@ -1,6 +1,6 @@
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const rules: TSESLint.FlatConfig.Rules = {
+const rules: FlatConfig.Rules = {
   "storybook/default-exports": "error",
   "storybook/hierarchy-separator": "warn",
   "storybook/no-redundant-story-name": "warn",

--- a/packages/configs/eslint-config-tailwindcss/eslint.config.mts
+++ b/packages/configs/eslint-config-tailwindcss/eslint.config.mts
@@ -1,7 +1,7 @@
 import * as base from "@zphyrx/eslint-config-internal";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config: TSESLint.FlatConfig.ConfigArray = [...base.config, {}];
+const config: FlatConfig.ConfigArray = [...base.config, {}];
 
 export default config;

--- a/packages/configs/eslint-config-tailwindcss/src/config.ts
+++ b/packages/configs/eslint-config-tailwindcss/src/config.ts
@@ -2,15 +2,15 @@ import tailwindcssPlugin from "eslint-plugin-tailwindcss";
 
 import { rulesTailwindcss } from "./rules";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const _extends: TSESLint.FlatConfig.ConfigArray = [
+const _extends: FlatConfig.ConfigArray = [
   ...tailwindcssPlugin.configs["flat/recommended"],
 ];
 
 const _files: (string | string[])[] = ["**/*.ts?(x)"];
 
-const _rules: TSESLint.FlatConfig.Rules = {
+const _rules: FlatConfig.Rules = {
   ...rulesTailwindcss,
 };
 

--- a/packages/configs/eslint-config-tailwindcss/src/rules/tailwindcss.ts
+++ b/packages/configs/eslint-config-tailwindcss/src/rules/tailwindcss.ts
@@ -1,6 +1,6 @@
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const rules: TSESLint.FlatConfig.Rules = {
+const rules: FlatConfig.Rules = {
   "tailwindcss/classnames-order": "warn",
   "tailwindcss/enforces-shorthand": "warn",
   // "tailwindcss/no-arbitrary-value": "off",

--- a/packages/configs/eslint-config-testing-library/eslint.config.mts
+++ b/packages/configs/eslint-config-testing-library/eslint.config.mts
@@ -1,7 +1,7 @@
 import * as base from "@zphyrx/eslint-config-internal";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config: TSESLint.FlatConfig.ConfigArray = [...base.config, {}];
+const config: FlatConfig.ConfigArray = [...base.config, {}];
 
 export default config;

--- a/packages/configs/eslint-config-testing-library/src/configs/react.ts
+++ b/packages/configs/eslint-config-testing-library/src/configs/react.ts
@@ -2,15 +2,15 @@ import testingLibraryPlugin from "eslint-plugin-testing-library";
 
 import { rulesReact } from "../rules";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const _extends: TSESLint.FlatConfig.ConfigArray = [
+const _extends: FlatConfig.ConfigArray = [
   testingLibraryPlugin.configs["flat/react"],
 ];
 
 const _files: (string | string[])[] = ["**/?(*.)+(spec|test).ts?(x)"];
 
-const _rules: TSESLint.FlatConfig.Rules = {
+const _rules: FlatConfig.Rules = {
   ...rulesReact,
 };
 

--- a/packages/configs/eslint-config-testing-library/src/configs/vue.ts
+++ b/packages/configs/eslint-config-testing-library/src/configs/vue.ts
@@ -2,15 +2,15 @@ import testingLibraryPlugin from "eslint-plugin-testing-library";
 
 import { rulesVue } from "../rules";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const _extends: TSESLint.FlatConfig.ConfigArray = [
+const _extends: FlatConfig.ConfigArray = [
   testingLibraryPlugin.configs["flat/vue"],
 ];
 
 const _files: (string | string[])[] = ["**/?(*.)+(spec|test).ts?(x)"];
 
-const _rules: TSESLint.FlatConfig.Rules = {
+const _rules: FlatConfig.Rules = {
   ...rulesVue,
 };
 

--- a/packages/configs/eslint-config-testing-library/src/rules/react.ts
+++ b/packages/configs/eslint-config-testing-library/src/rules/react.ts
@@ -1,6 +1,6 @@
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const rules: TSESLint.FlatConfig.Rules = {
+const rules: FlatConfig.Rules = {
   "testing-library/await-async-queries": "error",
   "testing-library/await-async-utils": "error",
   "testing-library/no-await-sync-events": "warn",

--- a/packages/configs/eslint-config-testing-library/src/rules/vue.ts
+++ b/packages/configs/eslint-config-testing-library/src/rules/vue.ts
@@ -1,6 +1,6 @@
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const rules: TSESLint.FlatConfig.Rules = {
+const rules: FlatConfig.Rules = {
   "testing-library/await-async-queries": "error",
   "testing-library/await-async-utils": "error",
   "testing-library/no-await-sync-queries": "warn",

--- a/packages/configs/eslint-config-typescript/eslint.config.mts
+++ b/packages/configs/eslint-config-typescript/eslint.config.mts
@@ -1,8 +1,8 @@
 import * as base from "@zphyrx/eslint-config-internal";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config: TSESLint.FlatConfig.ConfigArray = [
+const config: FlatConfig.ConfigArray = [
   ...base.config,
   {
     name: "@zphyrx/eslint-config-internal/import-x",

--- a/packages/configs/eslint-config-typescript/src/config.ts
+++ b/packages/configs/eslint-config-typescript/src/config.ts
@@ -2,16 +2,16 @@ import tseslint from "typescript-eslint";
 
 import { rulesTypeScript } from "./rules";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const _extends: TSESLint.FlatConfig.ConfigArray = [
+const _extends: FlatConfig.ConfigArray = [
   ...tseslint.configs.strictTypeChecked,
   ...tseslint.configs.stylisticTypeChecked,
 ];
 
 const _files: (string | string[])[] = ["**/*.ts?(x)", "**/*.mts"];
 
-const _languageOptions: TSESLint.FlatConfig.LanguageOptions = {
+const _languageOptions: FlatConfig.LanguageOptions = {
   parser: tseslint.parser,
   parserOptions: {
     sourceType: "module",
@@ -22,7 +22,7 @@ const _languageOptions: TSESLint.FlatConfig.LanguageOptions = {
   },
 };
 
-const _rules: TSESLint.FlatConfig.Rules = {
+const _rules: FlatConfig.Rules = {
   ...rulesTypeScript,
 };
 

--- a/packages/configs/eslint-config-typescript/src/rules/typescript.ts
+++ b/packages/configs/eslint-config-typescript/src/rules/typescript.ts
@@ -1,6 +1,6 @@
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const rules: TSESLint.FlatConfig.Rules = {
+const rules: FlatConfig.Rules = {
   "no-dupe-class-members": "off",
   "no-duplicate-imports": "error",
   "no-undef": "off",

--- a/packages/configs/eslint-config-vitest/eslint.config.mts
+++ b/packages/configs/eslint-config-vitest/eslint.config.mts
@@ -1,7 +1,7 @@
 import * as base from "@zphyrx/eslint-config-internal";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config: TSESLint.FlatConfig.ConfigArray = [...base.config, {}];
+const config: FlatConfig.ConfigArray = [...base.config, {}];
 
 export default config;

--- a/packages/configs/eslint-config-vitest/src/config.ts
+++ b/packages/configs/eslint-config-vitest/src/config.ts
@@ -2,15 +2,13 @@ import vitestPlugin from "@vitest/eslint-plugin";
 
 import { rulesVitest } from "./rules";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const _extends: TSESLint.FlatConfig.ConfigArray = [
-  vitestPlugin.configs.recommended,
-];
+const _extends: FlatConfig.ConfigArray = [vitestPlugin.configs.recommended];
 
 const _files: (string | string[])[] = ["**/?(*.)+(spec|test).ts?(x)"];
 
-const _rules: TSESLint.FlatConfig.Rules = {
+const _rules: FlatConfig.Rules = {
   ...rulesVitest,
 };
 

--- a/packages/configs/eslint-config-vitest/src/rules/vitest.ts
+++ b/packages/configs/eslint-config-vitest/src/rules/vitest.ts
@@ -1,6 +1,6 @@
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const rules: TSESLint.FlatConfig.Rules = {
+const rules: FlatConfig.Rules = {
   "vitest/consistent-test-it": [
     "warn",
     {

--- a/packages/configs/postcss-config/eslint.config.mts
+++ b/packages/configs/postcss-config/eslint.config.mts
@@ -1,7 +1,7 @@
 import * as base from "@zphyrx/eslint-config-internal";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config: TSESLint.FlatConfig.ConfigArray = [...base.config, {}];
+const config: FlatConfig.ConfigArray = [...base.config, {}];
 
 export default config;

--- a/packages/configs/prettier-config/eslint.config.mts
+++ b/packages/configs/prettier-config/eslint.config.mts
@@ -1,7 +1,7 @@
 import * as base from "@zphyrx/eslint-config-internal";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config: TSESLint.FlatConfig.ConfigArray = [...base.config, {}];
+const config: FlatConfig.ConfigArray = [...base.config, {}];
 
 export default config;

--- a/packages/configs/tsup-config/eslint.config.mts
+++ b/packages/configs/tsup-config/eslint.config.mts
@@ -1,7 +1,7 @@
 import * as base from "@zphyrx/eslint-config-internal";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config: TSESLint.FlatConfig.ConfigArray = [...base.config, {}];
+const config: FlatConfig.ConfigArray = [...base.config, {}];
 
 export default config;

--- a/packages/configs/vitest-config/eslint.config.mts
+++ b/packages/configs/vitest-config/eslint.config.mts
@@ -1,8 +1,8 @@
 import * as base from "@zphyrx/eslint-config-internal";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config: TSESLint.FlatConfig.ConfigArray = [
+const config: FlatConfig.ConfigArray = [
   ...base.config,
   {
     name: "@zphyrx/eslint-config-internal",

--- a/packages/helpers/exlint/eslint.config.mts
+++ b/packages/helpers/exlint/eslint.config.mts
@@ -1,8 +1,8 @@
 import * as base from "@zphyrx/eslint-config-internal";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config: TSESLint.FlatConfig.ConfigArray = [
+const config: FlatConfig.ConfigArray = [
   ...base.config,
   {
     name: "@zphyrx/eslint-config-internal",

--- a/packages/helpers/exlint/src/config.test.ts
+++ b/packages/helpers/exlint/src/config.test.ts
@@ -1,10 +1,10 @@
 import * as exlint from "./index";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
 describe("config helper", (): void => {
   it("should work without extends", (): void => {
-    const config: TSESLint.FlatConfig.ConfigArray = exlint.config({
+    const config: FlatConfig.ConfigArray = exlint.config({
       files: ["**/?(*.)+(spec|test).ts?(x)"],
       ignores: ["**/__tests__/**/*.ts?(x)"],
       rules: {
@@ -24,7 +24,7 @@ describe("config helper", (): void => {
   });
 
   it("should flatten extended configs", (): void => {
-    const config: TSESLint.FlatConfig.ConfigArray = exlint.config({
+    const config: FlatConfig.ConfigArray = exlint.config({
       extends: [
         {
           rules: {
@@ -62,7 +62,7 @@ describe("config helper", (): void => {
   });
 
   it("should flatten extended configs with files and ignores", (): void => {
-    const config: TSESLint.FlatConfig.ConfigArray = exlint.config({
+    const config: FlatConfig.ConfigArray = exlint.config({
       extends: [
         {
           rules: {
@@ -108,7 +108,7 @@ describe("config helper", (): void => {
   });
 
   it("should flatten extended configs with config name", (): void => {
-    const config: TSESLint.FlatConfig.ConfigArray = exlint.config({
+    const config: FlatConfig.ConfigArray = exlint.config({
       extends: [
         {
           rules: {
@@ -158,7 +158,7 @@ describe("config helper", (): void => {
   });
 
   it("should flatten extended configs with names if base config is unnamed", (): void => {
-    const config: TSESLint.FlatConfig.ConfigArray = exlint.config({
+    const config: FlatConfig.ConfigArray = exlint.config({
       extends: [
         {
           name: "extension-1",
@@ -206,7 +206,7 @@ describe("config helper", (): void => {
   });
 
   it("should merge config item names", (): void => {
-    const config: TSESLint.FlatConfig.ConfigArray = exlint.config({
+    const config: FlatConfig.ConfigArray = exlint.config({
       extends: [
         {
           name: "extension-1",
@@ -257,7 +257,7 @@ describe("config helper", (): void => {
   });
 
   it("should allow nested arrays in the config function", (): void => {
-    const config: TSESLint.FlatConfig.ConfigArray = exlint.config(
+    const config: FlatConfig.ConfigArray = exlint.config(
       {
         rules: {
           "vitest/no-test-return-statement": "warn",
@@ -335,7 +335,7 @@ describe("config helper", (): void => {
   });
 
   it("should allow nested arrays in extends", (): void => {
-    const config: TSESLint.FlatConfig.ConfigArray = exlint.config({
+    const config: FlatConfig.ConfigArray = exlint.config({
       extends: [
         {
           rules: {
@@ -423,13 +423,13 @@ describe("config helper", (): void => {
   });
 
   it("throws error containing config name when some extensions are undefined", (): void => {
-    const extension: TSESLint.FlatConfig.Config = {
+    const extension: FlatConfig.Config = {
       rules: {
         rule1: "error",
       },
     };
 
-    const config = (): TSESLint.FlatConfig.ConfigArray =>
+    const config = (): FlatConfig.ConfigArray =>
       exlint.config(
         {
           extends: [extension],
@@ -458,13 +458,13 @@ describe("config helper", (): void => {
   });
 
   it("throws error without config name when some extensions are undefined", (): void => {
-    const extension: TSESLint.FlatConfig.Config = {
+    const extension: FlatConfig.Config = {
       rules: {
         rule1: "error",
       },
     };
 
-    const config = (): TSESLint.FlatConfig.ConfigArray =>
+    const config = (): FlatConfig.ConfigArray =>
       exlint.config(
         {
           extends: [extension],

--- a/packages/helpers/exlint/src/config.ts
+++ b/packages/helpers/exlint/src/config.ts
@@ -1,14 +1,14 @@
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
 type FlatConfigWithExtends = ConfigWithExtends | FlatConfigWithExtends[];
 
-type ConfigWithExtends = TSESLint.FlatConfig.Config & {
+type ConfigWithExtends = FlatConfig.Config & {
   extends?: FlatConfigWithExtends[];
 };
 
 const config = (
   ...configs: FlatConfigWithExtends[]
-): TSESLint.FlatConfig.ConfigArray => {
+): FlatConfig.ConfigArray => {
   // @ts-expect-error
   const flattened = configs.flat(Infinity) as ConfigWithExtends[];
 
@@ -21,7 +21,7 @@ const config = (
 
     const undefinedExt = extendsFlattened
       .map((ext, extIndex) =>
-        (ext as TSESLint.FlatConfig.Config | undefined) == null ? extIndex : -1,
+        (ext as FlatConfig.Config | undefined) == null ? extIndex : -1,
       )
       .filter((index) => index !== -1);
 

--- a/packages/helpers/merge-config/eslint.config.mts
+++ b/packages/helpers/merge-config/eslint.config.mts
@@ -1,8 +1,8 @@
 import * as base from "@zphyrx/eslint-config-internal";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config: TSESLint.FlatConfig.ConfigArray = [
+const config: FlatConfig.ConfigArray = [
   ...base.config,
   {
     name: "@zphyrx/eslint-config-internal",


### PR DESCRIPTION
### Description

This PR refactors the imports for `@typescript-eslint/utils` throughout the codebase.

Specifically, it changes from:

```ts
import type { TSESLint } from "@typescript-eslint/utils";
```
to:
```ts
import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
```
