### PR TITLE
refactor(eslint-config-react): remove typescript's non-null assertion

### DIFF
--- a/.changeset/thirty-dodos-design.md
+++ b/.changeset/thirty-dodos-design.md
@@ -1,0 +1,5 @@
+---
+"@zphyrx/eslint-config-react": patch
+---
+
+Remove TypeScript’s non-null assertion (`!`) for `reacttPlugin.configs.recommended` in the `extends` field

--- a/packages/configs/eslint-config-react/eslint.config.mts
+++ b/packages/configs/eslint-config-react/eslint.config.mts
@@ -2,14 +2,6 @@ import * as base from "@zphyrx/eslint-config-internal";
 
 import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config: FlatConfig.ConfigArray = [
-  ...base.config,
-  {
-    name: "@zphyrx/eslint-config-internal/typescript",
-    rules: {
-      "@typescript-eslint/no-non-null-assertion": "off",
-    },
-  },
-];
+const config: FlatConfig.ConfigArray = [...base.config, {}];
 
 export default config;

--- a/packages/configs/eslint-config-react/src/config.ts
+++ b/packages/configs/eslint-config-react/src/config.ts
@@ -12,11 +12,9 @@ const compat = new FlatCompat({
   baseDirectory: cwd,
 });
 
-// TODO - Remove TypeScript’s non-null assertion (`!`).
 const _extends: FlatConfig.ConfigArray = [
-  reactPlugin.configs.flat!.recommended as FlatConfig.Config,
-  reactPlugin.configs.flat!.recommended as FlatConfig.Config,
-  reactPlugin.configs.flat!["jsx-runtime"] as FlatConfig.Config,
+  reactPlugin.configs.flat.recommended as FlatConfig.Config,
+  reactPlugin.configs.flat["jsx-runtime"] as FlatConfig.Config,
   ...fixupConfigRules(compat.extends("plugin:react-hooks/recommended")),
 ];
 


### PR DESCRIPTION
<!--

Thank you for your contribution! To help us process your pull request (PR) quickly, please follow the steps below:

- 📝 Use a clear and meaningful title for the PR, including the name of the modified package.
- 👀 Review your PR thoroughly to ensure you haven't missed anything.

-->

### Description

This PR removes the unnecessary non-null assertion (`!`) from `reactPlugin.configs.recommended` in the `extends` field of the `eslint-config-react` package.

Specifically, it changes from:

```ts
const _extends: TSESLint.FlatConfig.ConfigArray = [
  reactPlugin.configs.flat!.recommended as FlatConfig.Config,
  reactPlugin.configs.flat!["jsx-runtime"] as FlatConfig.Config
];
```

to:

```ts
const _extends: TSESLint.FlatConfig.ConfigArray = [
  reactPlugin.configs.flat.recommended as FlatConfig.Config,
  reactPlugin.configs.flat["jsx-runtime"] as FlatConfig.Config
];
```
