### PR TITLE
refactor(eslint-config-react): add plugins field

### DIFF
--- a/.changeset/famous-snakes-live.md
+++ b/.changeset/famous-snakes-live.md
@@ -1,0 +1,5 @@
+---
+"@zphyrx/eslint-config-react": minor
+---
+
+Add `plugins` field

--- a/packages/configs/eslint-config-react/eslint.config.mts
+++ b/packages/configs/eslint-config-react/eslint.config.mts
@@ -2,6 +2,16 @@ import * as base from "@zphyrx/eslint-config-internal";
 
 import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config: FlatConfig.ConfigArray = [...base.config, {}];
+const config: FlatConfig.ConfigArray = [
+  ...base.config,
+  {
+    name: "@zphyrx/eslint-config-internal/typescritp",
+    rules: {
+      "@typescript-eslint/restrict-template-expressions": "warn",
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+    },
+  },
+];
 
 export default config;

--- a/packages/configs/eslint-config-react/src/config.ts
+++ b/packages/configs/eslint-config-react/src/config.ts
@@ -1,27 +1,25 @@
 import reactPlugin from "eslint-plugin-react";
-import { fixupConfigRules } from "@eslint/compat";
-import { FlatCompat } from "@eslint/eslintrc";
+//@ts-expect-error -- missing type declaration file
+import reactHooksPlugin from "eslint-plugin-react-hooks";
 
 import { rulesReact, rulesReactHooks } from "./rules";
 
 import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const cwd = process.cwd();
-
-const compat = new FlatCompat({
-  baseDirectory: cwd,
-});
-
 const _extends: FlatConfig.ConfigArray = [
   reactPlugin.configs.flat.recommended as FlatConfig.Config,
   reactPlugin.configs.flat["jsx-runtime"] as FlatConfig.Config,
-  ...fixupConfigRules(compat.extends("plugin:react-hooks/recommended")),
 ];
 
 const _files: (string | string[])[] = ["**/*.ts?(x)", "**/*.mts"];
 
+const _plugins: FlatConfig.Plugins = {
+  "react-hooks": reactHooksPlugin,
+};
+
 const _rules: FlatConfig.Rules = {
   ...rulesReact,
+  ...reactHooksPlugin.configs.recommended.rules,
   ...rulesReactHooks,
 };
 
@@ -34,6 +32,7 @@ const _settings: FlatConfig.Settings = {
 const _config = {
   extends: _extends,
   files: _files,
+  plugins: _plugins,
   rules: _rules,
   settings: _settings,
 };
@@ -41,6 +40,7 @@ const _config = {
 export {
   _extends as extends,
   _files as files,
+  _plugins as plugins,
   _rules as rules,
   _settings as settings,
   _config as config,


### PR DESCRIPTION
<!--

Thank you for your contribution! To help us process your pull request (PR) quickly, please follow the steps below:

- 📝 Use a clear and meaningful title for the PR, including the name of the modified package.
- 👀 Review your PR thoroughly to ensure you haven't missed anything.

-->

### Description
This PR adds a `plugins` field to the `eslint-config-react` package.

- Removes `fixupConfigRules(compat.extends("plugin:react-hooks/recommended"))` from the `extends` field.
- Adds `"react-hooks"` to the new `plugins` field.
