### PR TITLE
refactor(eslint-config-react): remove `plugins` field

### DIFF
--- a/.changeset/mean-cougars-show.md
+++ b/.changeset/mean-cougars-show.md
@@ -1,0 +1,5 @@
+---
+"@zphyrx/eslint-config-react": minor
+---
+
+Remove `plugins` field

--- a/packages/configs/eslint-config-react/CHANGELOG.md
+++ b/packages/configs/eslint-config-react/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Patch Changes
 
-- d50ef6c: Remove TypeScript’s non-null assertion (`!`) for `reacttPlugin.configs.recommended` in the `extends` field
+- d50ef6c: Remove TypeScript’s non-null assertion (`!`) for `reactPlugin.configs.recommended` in the `extends` field
 
 ## 1.1.2
 

--- a/packages/configs/eslint-config-react/eslint.config.mts
+++ b/packages/configs/eslint-config-react/eslint.config.mts
@@ -5,11 +5,9 @@ import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 const config: FlatConfig.ConfigArray = [
   ...base.config,
   {
-    name: "@zphyrx/eslint-config-internal/typescritp",
+    name: "@zphyrx/eslint-config-internal/import-x",
     rules: {
-      "@typescript-eslint/restrict-template-expressions": "warn",
-      "@typescript-eslint/no-unsafe-assignment": "off",
-      "@typescript-eslint/no-unsafe-member-access": "off",
+      "import-x/default": "off",
     },
   },
 ];

--- a/packages/configs/eslint-config-react/src/config.ts
+++ b/packages/configs/eslint-config-react/src/config.ts
@@ -1,5 +1,4 @@
 import reactPlugin from "eslint-plugin-react";
-//@ts-expect-error -- missing type declaration file
 import reactHooksPlugin from "eslint-plugin-react-hooks";
 
 import { rulesReact, rulesReactHooks } from "./rules";
@@ -9,6 +8,7 @@ import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 const _extends: FlatConfig.ConfigArray = [
   reactPlugin.configs.flat.recommended as FlatConfig.Config,
   reactPlugin.configs.flat["jsx-runtime"] as FlatConfig.Config,
+  reactHooksPlugin.configs["recommended-latest"],
 ];
 
 const _files: (string | string[])[] = ["**/*.ts?(x)", "**/*.mts"];
@@ -19,7 +19,6 @@ const _plugins: FlatConfig.Plugins = {
 
 const _rules: FlatConfig.Rules = {
   ...rulesReact,
-  ...reactHooksPlugin.configs.recommended.rules,
   ...rulesReactHooks,
 };
 


### PR DESCRIPTION
<!--

Thank you for your contribution! To help us process your pull request (PR) quickly, please follow the steps below:

- 📝 Use a clear and meaningful title for the PR, including the name of the modified package.
- 👀 Review your PR thoroughly to ensure you haven't missed anything.

-->

### Description

This PR removes the `plugins` field from the `eslint-config-react` package.

